### PR TITLE
zentool: Fix building on a newer toolchain

### DIFF
--- a/pocs/cpus/entrysign/zentool/Makefile
+++ b/pocs/cpus/entrysign/zentool/Makefile
@@ -7,7 +7,7 @@ VERSION=0.01
 # List of all required dependencies in pkg-config format.
 PKGDEPS=openssl,gmp,json-c
 
-.PHONY: clean distclean sync check template.bin
+.PHONY: all clean distclean sync check template.bin
 
 all: check zentool mcop mcas opcodes mtalk dumper
 
@@ -44,10 +44,14 @@ sync:
 %.o: %.asm
 	nasm $(NFLAGS) -felf64 -o $@ $^
 
+.INTERMEDIATE: %_fields.h.pahole
+%_fields.h.pahole: CLASS=$(patsubst %_fields.h.pahole,%,$@)
+%_fields.h.pahole: structs.o ucode.h risc86.h
+	pahole -C $(CLASS) $< > $@
+
 .ONESHELL:
-%_fields.h: CLASS=$(patsubst %_fields.h,%,$@)
-%_fields.h: structs.o ucode.h risc86.h
-	pahole -C $(CLASS) $<  | awk 'BEGIN {
+%_fields.h: %_fields.h.pahole
+	awk < $< 'BEGIN {
 		print "/* This file was automatically generated */"
 	}	/unsigned int/ && $$3 !~ /^_/ {
 			printf("REGISTER_BITFIELD($(CLASS), %s);\n",gensub(/:.*/, "", 1, $$3))
@@ -83,7 +87,7 @@ template.bin: zentool
 	./zentool resign $@
 
 clean:
-	rm -f *.o zentool mcas mcop mtalk opcodes dumper template.bin
+	rm -f *.o *.h.pahole zentool mcas mcop mtalk opcodes dumper template.bin
 	rm -f zentool-$(VERSION).tar.gz
 
 distclean: clean

--- a/pocs/cpus/entrysign/zentool/edit.c
+++ b/pocs/cpus/entrysign/zentool/edit.c
@@ -153,7 +153,7 @@ static int set_sequence_word(patch_t *patch, char const *options)
     return 0;
 }
 
-static int set_fastpath_hook(patch_t *patch, char const *options)
+static int set_fastpath_hook(patch_t *patch, char *options)
 {
 /*
 ./zentool --output=modified.bin edit --nop all --match all=0 --seq all=7 --insn q40i0="xor rax, rax, rax" --insn q40i1="add rax, rax, 0x1337" --fastpath 0xbb000000,0xff000000,0x00000005 --hdr-revlow 0x6 template.bin && ./zentool resign modified.bin && sudo ./zentool load --cpu=2 modified.bin && taskset -c 2 ./opcodes
@@ -375,6 +375,7 @@ int cmd_edit_main(int argc, char **argv)
         } else if (strcmp(opt, "insn-field") == 0) {
             set_insn_field(patch, optarg);
         } else if (strcmp(opt, "fastpath") == 0) {
+            // Careful! set_fastpath_hook() destroys `optarg` when splitting it.
             set_fastpath_hook(patch, optarg);
         } else {
             errx(EXIT_FAILURE, "BUG: option %s not handled", opt);


### PR DESCRIPTION
Or at least try to, there are still some issues with pahole, but seems I need to contribute the fixes upstream.

Context for these:
```
cc -std=gnu2x -Og -ggdb3 -I/usr/include/json-c -mavx -march=znver2 -Wall -W -D_GNU_SOURCE -DZENTOOL_VERSION=\"0.01\" -mavx -march=znver2  -c -o edit.o edit.c
edit.c: In function ‘set_fastpath_hook’:
edit.c:162:31: warning: passing argument 1 of ‘str_split’ discards ‘const’ qualifier from pointer target type [-Wdiscarded-qualifiers]
  162 |     char **values = str_split(options, ',');
      |                               ^~~~~~~
In file included from edit.c:30:
util.h:34:24: note: expected ‘char *’ but argument is of type ‘const char *’
   34 | char** str_split(char* a_str, const char a_delim);
      |                  ~~~~~~^~~~~
```

and for the Makefile bug: you shouldn't use pipes in Makefiles, if a command on the left of it fails, then the whole line still succeeds. So, I ran Make -> pahole failed -> I changed something -> build "succeeded". But it was incorrect, pahole was never called again because of this bug.