### PR TITLE
Fix crash on print --all for ZenUtils patches + minor improvements

### DIFF
--- a/pocs/cpus/entrysign/zentool/README.md
+++ b/pocs/cpus/entrysign/zentool/README.md
@@ -42,9 +42,9 @@ Cpuid:       00008601 AMD Ryzen (Grey Hawk, Renoir)
 BiosRev:     00
 Flags:       00
 Reserved:    0000
-Signature:   9c... (use --verbose to see) (GOOD)
-Modulus:     c7... (use --verbose to see)
-Check:       5a... (use --verbose to see) (GOOD)
+Signature:   9c... (use global --verbose to see) (GOOD)
+Modulus:     c7... (use global --verbose to see)
+Check:       5a... (use global --verbose to see) (GOOD)
 Autorun:     false
 Encrypted:   false
 Revision:    0860010f (Signed)
@@ -105,7 +105,7 @@ such as the match registers and instruction quads.
 ```
 $ zentool print --match-regs modified.bin
 ; Patch 0x8600141 Match Registers (22 total)
-; (use --verbose to see empty slots)
+; (use global --verbose to see empty slots)
 	[0 ] 07CE
 	[1 ] 092D
 	[2 ] 1129
@@ -146,7 +146,7 @@ You can also try to disassemble the instruction quads, like this:
 ```
 $ zentool print --disassemble modified.bin
 ; Patch 0x8600141 OpQuad Disassembly (64 total)
-; (use --verbose to see further details)
+; (use global --verbose to see further details)
 .quad  2, 0x04021ff3
 	shr     	reg12, reg12, reg11
 	mov.b   	reg10, reg10, reg17

--- a/pocs/cpus/entrysign/zentool/docs/intro.md
+++ b/pocs/cpus/entrysign/zentool/docs/intro.md
@@ -245,9 +245,9 @@ Cpuid:      00008310 Rome, Castle Peak
 Biosrev:    08
 Flags:      00
 Reserved:   0000
-Signature:  7a... (use --verbose to see)
-Modulus:    c7... (use --verbose to see)
-Hash:       5a... (use --verbose to see)
+Signature:  7a... (use global --verbose to see)
+Modulus:    c7... (use global --verbose to see)
+Hash:       5a... (use global --verbose to see)
 Autorun:    01
 Encrypted:  00
 Revision:   0830107c (Signed)

--- a/pocs/cpus/entrysign/zentool/docs/intro.md
+++ b/pocs/cpus/entrysign/zentool/docs/intro.md
@@ -46,6 +46,11 @@ is loaded from that address it will be redirected to patch RAM instead. If
 you're a software person like me, you might think of this as more like
 "hooking" than "patching".
 
+These hooks can't be placed freely in patch RAM though -- they are arranged in
+fixed slots (called quads), and match register N will always redirect 
+to quad 2N. The slots in between can still be used, but only by continuing into 
+them from adjacent code.
+
 ![Patch RAM](img/patchram.png)
 
 There's a big catch, these resources are super limited! Like, really really
@@ -295,10 +300,11 @@ to put a constant into `rax`. Let's pick a rarely used instruction for now that
 
 First, we need to set a match register, so set match register zero to `@fpatan`.
 The `@` symbol simply indicates you want to use a symbolic instruction name rather
-than a number.
+than a number. Recall that match register N redirects to quad 2N, so match
+register 0 redirects to quad 0, match register 1 to quad 2, and so on.
 
 ```
-$ zentool edit --match 0,1=@fpatan template.bin
+$ zentool edit --match 0=@fpatan template.bin
 ```
 
 > Note: This only works if the correct match register for this CPU is known,
@@ -433,4 +439,3 @@ That worked, we changed the definition of `fpatan` on the core with the new micr
 - Reading memory
 - Writing memory
 - Producing output (VGA?)
-

--- a/pocs/cpus/entrysign/zentool/dump.c
+++ b/pocs/cpus/entrysign/zentool/dump.c
@@ -112,7 +112,7 @@ static void dump_ucode_hdr(const patch_t *patch)
     if (memcmp(signedhash, actualhash, sizeof signedhash) == 0)
         verified = true;
 
-    putmsg("Signature:   %02x... (use --verbose to see) (%s)",
+    putmsg("Signature:   %02x... (use global --verbose to see) (%s)",
         hdr->signature[0],
         verified ? "GOOD" : "BAD");
 
@@ -126,7 +126,7 @@ static void dump_ucode_hdr(const patch_t *patch)
         loghex(actualhash, 16);
     }
 
-    putmsg("Modulus:     %02x... (use --verbose to see)", hdr->modulus[0]);
+    putmsg("Modulus:     %02x... (use global --verbose to see)", hdr->modulus[0]);
 
     if (options.verbose)
         loghex(hdr->modulus, sizeof hdr->modulus);
@@ -144,7 +144,7 @@ static void dump_ucode_hdr(const patch_t *patch)
     if (memcmp(check, hdr->check, sizeof hdr->check) == 0)
         verified = true;
 
-    putmsg("Check:       %02x... (use --verbose to see) (%s)",
+    putmsg("Check:       %02x... (use global --verbose to see) (%s)",
         hdr->check[0],
         verified ? "GOOD" : "BAD");
 
@@ -223,7 +223,7 @@ int cmd_dump_main(int argc, char **argv)
         logmsg("; Patch %#x Match Registers (%u total)", patch->hdr.revision, patch->nmatch * 2);
 
         if (!options.verbose) {
-            logmsg("; (use --verbose to see empty slots)");
+            logmsg("; (use global --verbose to see empty slots)");
         }
 
         for (size_t i = 0; i < patch->nmatch; i++) {
@@ -260,7 +260,7 @@ int cmd_dump_main(int argc, char **argv)
         logmsg("; Patch %#0x OpQuad Disassembly (%u total)", patch->hdr.revision, patch->nquad);
 
         if (!options.verbose) {
-            logmsg("; (use --verbose to see further details)");
+            logmsg("; (use global --verbose to see further details)");
         }
 
         for (size_t i = 0; i < patch->nquad; i++) {

--- a/pocs/cpus/entrysign/zentool/factor.c
+++ b/pocs/cpus/entrysign/zentool/factor.c
@@ -114,6 +114,14 @@ bool crypt_signed_hash(uint8_t hash[16], const uint8_t *modulus, const uint8_t *
 
     // Extract the last few bytes, then read them back in.
     buf = mpz_export(NULL, NULL, -1, 16, 1, 0, h);
+
+    if (buf == NULL) {
+        // mpz_export returns NULL when the value is zero
+        memset(hash, 0, 16);
+        mpz_clears(s, n, h, NULL);
+        return false;
+    }
+
     mpz_import(h, 16, 1, 1, 0, 0, buf);
 
     if (options.debug) {

--- a/pocs/cpus/entrysign/zentool/factor.c
+++ b/pocs/cpus/entrysign/zentool/factor.c
@@ -79,9 +79,10 @@ bool crypt_hash_bytes(uint8_t hash[16], const void *buffer, size_t nbytes)
 
     dbgmsg("hashing %u bytes of data", nbytes);
 
+    size_t hash_len;
     CMAC_Init(ctx, kCMACKey, sizeof kCMACKey, EVP_aes_128_cbc(), NULL);
     CMAC_Update(ctx, buffer, nbytes);
-    CMAC_Final(ctx, hash, NULL);
+    CMAC_Final(ctx, hash, &hash_len);
 
     if (options.debug) {
         dbgmsg("hashing complete, result:");
@@ -142,7 +143,8 @@ bool crypt_patch_hash(uint8_t hash[16], const patch_t *patch)
     CMAC_Update(ctx, &patch->hdr.options, sizeof(patch->hdr) - offsetof(struct ucodehdr, options));
     CMAC_Update(ctx, patch->matchregs, sizeof(*patch->matchregs) * patch->nmatch);
     CMAC_Update(ctx, patch->insns, sizeof(*patch->insns) * patch->nquad);
-    CMAC_Final(ctx, hash, NULL);
+    size_t hash_len;
+    CMAC_Final(ctx, hash, &hash_len);
     CMAC_CTX_free(ctx);
     return 0;
 }

--- a/pocs/cpus/entrysign/zentool/preimage.c
+++ b/pocs/cpus/entrysign/zentool/preimage.c
@@ -188,7 +188,8 @@ int fixup_patch_hash(patch_t *patch, int offset)
 
     CMAC_Init(ctx, kCMACKey, sizeof kCMACKey, EVP_aes_128_cbc(), NULL);
     CMAC_Update(ctx, paddedInput, preimagesz);
-    CMAC_Final(ctx, result, NULL);
+    size_t result_len;
+    CMAC_Final(ctx, result, &result_len);
     CMAC_CTX_free(ctx);
 
     if (memcmp(result, target, bs) != 0) {

--- a/pocs/cpus/entrysign/zentool/test/expected_output.txt
+++ b/pocs/cpus/entrysign/zentool/test/expected_output.txt
@@ -15,9 +15,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  4f... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  4f... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   0830101c (Signed)
@@ -39,9 +39,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  86... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  86... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   08301025 (Signed)
@@ -63,9 +63,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  9e... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  9e... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   08301034 (Signed)
@@ -87,9 +87,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  99... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  99... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   08301038 (Signed)
@@ -111,9 +111,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  09... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  09... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   08301039 (Signed)
@@ -135,9 +135,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  aa... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  aa... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   0830104d (Signed)
@@ -159,9 +159,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  0b... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  0b... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   08301052 (Signed)
@@ -183,9 +183,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  9d... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  9d... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    true
 Encrypted:  false
 Revision:   08301055 (Signed)
@@ -207,9 +207,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  6d... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  6d... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    true
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -232,9 +232,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  88... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  88... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    true
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -257,9 +257,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  85... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  85... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    true
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -282,9 +282,9 @@ Cpuid:      00008310 Zen/Zen+/Zen2
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  7a... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  7a... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    true
 Encrypted:  false
 Revision:   0830107c (Signed)
@@ -306,9 +306,9 @@ Cpuid:      00008601 AMD Ryzen (Grey Hawk, Renoir)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  0b... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  0b... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   08600102 (Signed)
@@ -330,9 +330,9 @@ Cpuid:      00008601 AMD Ryzen (Grey Hawk, Renoir)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  03... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  03... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   08600103 (Signed)
@@ -354,9 +354,9 @@ Cpuid:      00008601 AMD Ryzen (Grey Hawk, Renoir)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  11... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  11... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   08600104 (Signed)
@@ -378,9 +378,9 @@ Cpuid:      00008601 AMD Ryzen (Grey Hawk, Renoir)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  a4... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  a4... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   08600106 (Signed)
@@ -402,9 +402,9 @@ Cpuid:      00008601 AMD Ryzen (Grey Hawk, Renoir)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  76... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  76... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    true
 Encrypted:  false
 Revision:   08600109 (Signed)
@@ -426,9 +426,9 @@ Cpuid:      00008601 AMD Ryzen (Grey Hawk, Renoir)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  77... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  77... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    true
 Encrypted:  false
 Revision:   0860010c (Signed)
@@ -450,9 +450,9 @@ Cpuid:      00008681 AMD Ryzen (Zen2, Lucienne)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  8a... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  8a... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   08608103 (Signed)
@@ -474,9 +474,9 @@ Cpuid:      0000a400 AMD Ryzen (Zen3+, Rembrandt)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  69... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  69... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   0a400016 (Signed)
@@ -498,9 +498,9 @@ Cpuid:      0000a440 Zen3/Zen4
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  99... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  99... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   0a404002 (Signed)
@@ -522,9 +522,9 @@ Cpuid:      0000a441 Zen3/Zen4
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  51... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  51... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   0a404101 (Signed)
@@ -546,9 +546,9 @@ Cpuid:      0000a441 Zen3/Zen4
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  7d... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  7d... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  false
 Revision:   0a404102 (Signed)
@@ -570,9 +570,9 @@ Cpuid:      0000a441 Zen3/Zen4
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  8a... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  8a... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -595,9 +595,9 @@ Cpuid:      0000a500 AMD Ryzen (Zen3, Cezanne/Barcelo)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  ae... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  ae... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -620,9 +620,9 @@ Cpuid:      0000a500 AMD Ryzen (Zen3, Cezanne/Barcelo)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  94... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  94... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -645,9 +645,9 @@ Cpuid:      0000a500 AMD Ryzen (Zen3, Cezanne/Barcelo)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  1a... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  1a... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -670,9 +670,9 @@ Cpuid:      0000a500 AMD Ryzen (Zen3, Cezanne/Barcelo)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  6a... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  6a... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -695,9 +695,9 @@ Cpuid:      0000a500 AMD Ryzen (Zen3, Cezanne/Barcelo)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  54... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  54... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -720,9 +720,9 @@ Cpuid:      0000a700 AMD Ryzen (Zen4, Phoenix)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  1c... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  1c... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -745,9 +745,9 @@ Cpuid:      0000a740 Zen3/Zen4
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  92... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  92... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -770,9 +770,9 @@ Cpuid:      0000a741 Zen3/Zen4
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  9b... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  9b... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    true
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -795,9 +795,9 @@ Cpuid:      0000a741 Zen3/Zen4
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  6c... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  6c... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -820,9 +820,9 @@ Cpuid:      0000a742 Zen3/Zen4
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  72... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  72... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -845,9 +845,9 @@ Cpuid:      0000a742 Zen3/Zen4
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  8f... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  8f... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -870,9 +870,9 @@ Cpuid:      0000a752 Zen3/Zen4
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  35... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  35... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -895,9 +895,9 @@ Cpuid:      0000a752 Zen3/Zen4
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  a6... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  a6... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    true
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -920,9 +920,9 @@ Cpuid:      0000a780 AMD Ryzen (Phoenix 2)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  03... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  03... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -945,9 +945,9 @@ Cpuid:      0000a780 AMD Ryzen (Phoenix 2)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  8d... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  8d... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -970,9 +970,9 @@ Cpuid:      0000a780 AMD Ryzen (Phoenix 2)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  a6... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  a6... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    true
 Encrypted:  true
     Use `zentool decrypt` to decrypt update
@@ -995,9 +995,9 @@ Cpuid:      0000a7c0 AMD Ryzen (Hawk Point)
 BiosRev:     00
 Flags:      00
 Reserved:   0000
-Signature:  c6... (use --verbose to see) (GOOD)
-Modulus:    c7... (use --verbose to see)
-Check:      5a... (use --verbose to see) (GOOD)
+Signature:  c6... (use global --verbose to see) (GOOD)
+Modulus:    c7... (use global --verbose to see)
+Check:      5a... (use global --verbose to see) (GOOD)
 Autorun:    false
 Encrypted:  true
     Use `zentool decrypt` to decrypt update


### PR DESCRIPTION
Fixes a segfault when disassembling certain ZenUtils microcode patches with `print --all`. The crash happened in `crypt_signed_hash` because `mpz_export` returns NULL when the operand is zero, and the result was used without a null check.

Also includes:
- Corrected match register addressing in the `intro.md` with the understanding from last week's discussion
- Added "global" to the `--verbose` flag description, since we've stumbled over its scope a few times (wording suggestions welcome)
