### PR TITLE
Fix CVE typo in CVE-2025-40364_lts_cos metadata

### DIFF
--- a/pocs/linux/kernelctf/CVE-2025-40364_lts_cos/metadata.json
+++ b/pocs/linux/kernelctf/CVE-2025-40364_lts_cos/metadata.json
@@ -6,7 +6,7 @@
     ],
     "vulnerability":{
        "patch_commit":"https://git.kernel.org/pub/scm/linux/kernel/git/stable/linux.git/commit/?id=a94592ec30ff67dc36c424327f1e0a9ceeeb9bd3",
-       "cve":"CVE-2024-40364",
+       "cve":"CVE-2025-40364",
        "affected_versions":[
           "5.19 - 6.14"
        ],


### PR DESCRIPTION
The metadata.json incorrectly lists CVE-2024-40364 instead of CVE-2025-40364, mismatching the directory name.

Fixes #358