### PR TITLE
kernelCTF: make vuln-verify look at the old submissions

### DIFF
--- a/kernelctf/vuln-verify/verify.py
+++ b/kernelctf/vuln-verify/verify.py
@@ -65,7 +65,7 @@ if not GITHUB_TOKEN and not args.no_gh_auth:
 GH_HEADERS = {"Authorization": f"Bearer {GITHUB_TOKEN}"} if GITHUB_TOKEN and not args.no_gh_auth else {}
 
 CACHE_DB_FN = "cache.json"
-PUBLIC_CSV_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vS1REdTA29OJftst8xN5B5x8iIUcxuK6bXdzF8G1UXCmRtoNsoQ9MbebdRdFnj6qZ0Yd7LwQfvYC2oF/pub?output=csv"
+PUBLIC_CSV_URL = "https://docs.google.com/spreadsheets/d/e/2PACX-1vS1REdTA29OJftst8xN5B5x8iIUcxuK6bXdzF8G1UXCmRtoNsoQ9MbebdRdFnj6qZ0Yd7LwQfvYC2oF/pub?output=csv&gid=2095368189"
 KERNEL_DANCE_SQL_URL = "https://linux-mirror-db.storage.googleapis.com/mirror.sl3"
 KERNEL_DANCE_SQL_FN = "kernel-dance.sqlite3"
 KERNELCTF_RELEASES_URL = "https://storage.googleapis.com/kernelctf-build/releases"


### PR DESCRIPTION
vuln-verify searches for the patch commit of a submission in the public spreadsheet. That spreadsheet only used to contain a list of all submissions, but with the switch to the new rules we created new sheets and now the first sheet is for the winners. This makes vuln-verify fail because it can't find the patch commit anymore. Make it look at the correct sheet instead. This will break vuln-verify for the submissions under the new rules so we will need to fix that in the future but this should be ok for now.

See #424 for an example of where this broke.