### PR TITLE
Add CodeQL queries and data processor for syscall reachability nodes

### DIFF
--- a/analysis/kernel/dashboard/Data/CodeQL/import_syscall_node.py
+++ b/analysis/kernel/dashboard/Data/CodeQL/import_syscall_node.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+"""Build the syscall_node table from the two split CodeQL query outputs."""
+import argparse
+import csv
+import os
+import sqlite3
+import sys
+from collections import defaultdict
+
+try:
+    from utils import detect_prefix, trim_filename
+except ImportError:
+    from Data.CodeQL.utils import detect_prefix, trim_filename
+
+
+def loc_string(file, sl, sc, el, ec):
+    """Assemble a 'file:startLine:startCol:endLine:endCol' location string."""
+    return f"{file}:{sl}:{sc}:{el}:{ec}"
+
+
+def load_locs(path):
+    """
+    Load location components from locs.csv.
+    Returns:
+      by_fn_file: map of (function_name, relative_file) -> list of location strings
+      by_name: map of function_name -> list of (relative_file, location_string)
+      prefix: detected common root directory prefix
+    """
+    sample_files = []
+    with open(path, newline="", encoding="utf-8", errors="ignore") as f:
+        reader = csv.reader(f)
+        for row in reader:
+            if len(row) >= 2 and row[1]:
+                sample_files.append(row[1].strip().strip('"'))
+                if len(sample_files) >= 1000:
+                    break
+
+    prefix = detect_prefix(sample_files)
+
+    by_fn_file = defaultdict(list)
+    by_name = defaultdict(list)
+
+    with open(path, newline="", encoding="utf-8", errors="ignore") as f:
+        for row in csv.reader(f):
+            if len(row) < 6:
+                continue
+            name = row[0].strip().strip('"')
+            raw_file = row[1].strip().strip('"')
+            file = trim_filename(raw_file, prefix)
+            sl, sc, el, ec = row[2], row[3], row[4], row[5]
+            loc = loc_string(file, sl, sc, el, ec)
+            by_fn_file[(name, file)].append(loc)
+            by_name[name].append((file, loc))
+
+    return by_fn_file, by_name, prefix
+
+
+def syscall_locations(by_name):
+    """Map each __do_sys_* entry to its definition location, preferring .c files."""
+    out = {}
+    for name, file_loc_pairs in by_name.items():
+        if name.startswith("__do_sys_"):
+            c_locs = [loc for file, loc in file_loc_pairs if file.endswith(".c")]
+            if c_locs:
+                out[name] = c_locs[0]
+            elif file_loc_pairs:
+                out[name] = file_loc_pairs[0][1]
+    return out
+
+
+def gen_rows(pairs_path, by_fn_file, by_name, sysloc, prefix=""):
+    """
+    Yield (syscall, function, syscall_location, function_location) rows.
+    If pairs.csv provides a 3rd column (file), joins on (function, file) to
+    eliminate cross-file Cartesian collisions on duplicate function names.
+    """
+    miss_fn = miss_sys = 0
+    seen = set()
+
+    with open(pairs_path, newline="", encoding="utf-8", errors="ignore") as f:
+        for row in csv.reader(f):
+            if len(row) < 2:
+                continue
+            syscall = row[0].strip().strip('"')
+            function = row[1].strip().strip('"')
+            if syscall == "syscall" and function == "function":
+                continue  # Header row
+
+            sloc = sysloc.get(syscall)
+            if sloc is None:
+                miss_sys += 1
+                continue
+
+            # Check if file path is available in column 3
+            if len(row) >= 3 and row[2].strip().strip('"'):
+                raw_file = row[2].strip().strip('"')
+                file = trim_filename(raw_file, prefix)
+                flocs = by_fn_file.get((function, file))
+                if not flocs:
+                    # Fallback to by_name if file-specific match not found
+                    flocs = [loc for _, loc in by_name.get(function, [])]
+            else:
+                flocs = [loc for _, loc in by_name.get(function, [])]
+
+            if not flocs:
+                miss_fn += 1
+                continue
+
+            for floc in flocs:
+                row_tuple = (syscall, function, sloc, floc)
+                if row_tuple not in seen:
+                    seen.add(row_tuple)
+                    yield row_tuple
+
+    if miss_fn:
+        print(f"WARNING: {miss_fn} pairs had a function with no location", file=sys.stderr)
+    if miss_sys:
+        print(f"WARNING: {miss_sys} pairs had a syscall with no root location", file=sys.stderr)
+
+
+def write_db(db_path, rows):
+    """Drop, recreate and index the syscall_node table, then insert all rows."""
+    con = sqlite3.connect(db_path)
+    con.execute("DROP TABLE IF EXISTS syscall_node")
+    con.execute(
+        "CREATE TABLE syscall_node ("
+        "syscall TEXT, function TEXT, syscall_location TEXT, function_location TEXT)"
+    )
+    con.executemany("INSERT INTO syscall_node VALUES (?,?,?,?)", rows)
+    con.execute("CREATE INDEX idx_syscall_node_function ON syscall_node(function)")
+    con.execute("CREATE INDEX idx_syscall_node_syscall ON syscall_node(syscall)")
+    con.commit()
+    n = con.execute("SELECT count(*) FROM syscall_node").fetchone()[0]
+    con.close()
+    print(f"built {db_path}: syscall_node has {n} rows", file=sys.stderr)
+
+
+def write_csv(out_path, rows):
+    """Write all rows to a CSV file."""
+    with open(out_path, "w", newline="", encoding="utf-8") as f:
+        w = csv.writer(f)
+        n = sum(1 for _ in map(w.writerow, rows))
+    print(f"wrote {n} rows to {out_path}", file=sys.stderr)
+
+
+def main():
+    ap = argparse.ArgumentParser(
+        description="Assemble syscall_node table/CSV from split CodeQL query outputs."
+    )
+    ap.add_argument(
+        "--pairs",
+        required=True,
+        help="syscall-node-pairs.ql output (syscall, function[, file])",
+    )
+    ap.add_argument(
+        "--locs",
+        required=True,
+        help="syscall-node-locs.ql output (name, file, sl, sc, el, ec)",
+    )
+    ap.add_argument("--db", help="build/refresh syscall_node in this SQLite DB (primary mode)")
+    ap.add_argument("--out", help="alternatively, write the rows to a CSV file")
+    args = ap.parse_args()
+
+    if not os.path.isfile(args.pairs):
+        sys.exit(f"Error: pairs file not found: {args.pairs}")
+    if not os.path.isfile(args.locs):
+        sys.exit(f"Error: locs file not found: {args.locs}")
+    if not args.db and not args.out:
+        sys.exit("need --out or --db")
+
+    by_fn_file, by_name, prefix = load_locs(args.locs)
+    sysloc = syscall_locations(by_name)
+    rows = gen_rows(args.pairs, by_fn_file, by_name, sysloc, prefix)
+
+    if args.db:
+        write_db(args.db, rows)
+    elif args.out:
+        write_csv(args.out, rows)
+
+
+if __name__ == "__main__":
+    main()

--- a/analysis/kernel/dashboard/Data/CodeQL/tests/test_imports.py
+++ b/analysis/kernel/dashboard/Data/CodeQL/tests/test_imports.py
@@ -22,6 +22,7 @@ import import_macro_invocations
 import import_macros
 import import_ops_targets
 import import_syscall_reachable
+import import_syscall_node
 from utils import detect_prefix, trim_filename
 
 
@@ -444,6 +445,72 @@ class TestImportOpsTargets(BaseImporterTest):
         with patch("sys.argv", ["import_ops_targets.py", missing_csv, self.db_path]):
             with self.assertRaises(SystemExit):
                 import_ops_targets.main()
+
+
+class TestImportSyscallNode(BaseImporterTest):
+    def setUp(self):
+        super().setUp()
+        self.locs_path = os.path.join(self.tmp_dir.name, "locs.csv")
+        self.pairs_path = os.path.join(self.tmp_dir.name, "pairs.csv")
+        self.out_csv = os.path.join(self.tmp_dir.name, "syscall_node.csv")
+
+    def test_import_3col_exact_join(self):
+        with open(self.locs_path, "w", encoding="utf-8") as f:
+            f.write('"__do_sys_openat","linux/fs/open.c",100,1,120,20\n')
+            f.write('"hash","linux/fs/inode.c",50,1,60,20\n')
+            f.write('"hash","linux/kernel/bpf/bloom_filter.c",70,1,80,20\n')
+
+        with open(self.pairs_path, "w", encoding="utf-8") as f:
+            f.write('"__do_sys_openat","hash","linux/fs/inode.c"\n')
+
+        by_fn_file, by_name, prefix = import_syscall_node.load_locs(self.locs_path)
+        sysloc = import_syscall_node.syscall_locations(by_name)
+        rows = list(import_syscall_node.gen_rows(self.pairs_path, by_fn_file, by_name, sysloc, prefix))
+
+        self.assertEqual(len(rows), 1)
+        self.assertEqual(
+            rows[0],
+            ("__do_sys_openat", "hash", "fs/open.c:100:1:120:20", "fs/inode.c:50:1:60:20"),
+        )
+
+        import_syscall_node.write_db(self.db_path, rows)
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT count(*) FROM syscall_node")
+        self.assertEqual(cursor.fetchone()[0], 1)
+        conn.close()
+
+    def test_import_2col_fallback(self):
+        with open(self.locs_path, "w", encoding="utf-8") as f:
+            f.write('"__do_sys_openat","linux/fs/open.c",100,1,120,20\n')
+            f.write('"hash","linux/fs/inode.c",50,1,60,20\n')
+            f.write('"hash","linux/kernel/bpf/bloom_filter.c",70,1,80,20\n')
+
+        with open(self.pairs_path, "w", encoding="utf-8") as f:
+            f.write('"__do_sys_openat","hash"\n')
+
+        by_fn_file, by_name, prefix = import_syscall_node.load_locs(self.locs_path)
+        sysloc = import_syscall_node.syscall_locations(by_name)
+        rows = list(import_syscall_node.gen_rows(self.pairs_path, by_fn_file, by_name, sysloc, prefix))
+
+        self.assertEqual(len(rows), 2)
+
+    def test_cli_main(self):
+        with open(self.locs_path, "w", encoding="utf-8") as f:
+            f.write('"__do_sys_openat","linux/fs/open.c",100,1,120,20\n')
+            f.write('"vfs_read","linux/fs/read_write.c",200,1,220,20\n')
+
+        with open(self.pairs_path, "w", encoding="utf-8") as f:
+            f.write('"__do_sys_openat","vfs_read","linux/fs/read_write.c"\n')
+
+        with patch("sys.argv", ["import_syscall_node.py", "--pairs", self.pairs_path, "--locs", self.locs_path, "--db", self.db_path]):
+            import_syscall_node.main()
+
+        conn = sqlite3.connect(self.db_path)
+        cursor = conn.cursor()
+        cursor.execute("SELECT count(*) FROM syscall_node")
+        self.assertEqual(cursor.fetchone()[0], 1)
+        conn.close()
 
 
 if __name__ == "__main__":

--- a/analysis/kernel/dashboard/queries/syscall-node-locs.ql
+++ b/analysis/kernel/dashboard/queries/syscall-node-locs.ql
@@ -1,0 +1,24 @@
+/**
+ * @name Function location components
+ * @description Emits each function's name and definition location as separate
+ *   columns (file, startLine, startCol, endLine, endCol) rather than an assembled
+ *   string.
+ * @id cpp/dashboard/syscall-node-locs
+ * @kind table
+ */
+
+import cpp
+
+from Function f, Location l
+where
+  exists(f.getBlock()) and
+  not f.getName().matches("__compiletime_assert_%") and
+  not f.getName().matches("__builtin_%") and
+  l = f.getLocation()
+select
+  f.getName() as name,
+  l.getFile().getRelativePath() as file,
+  l.getStartLine() as startLine,
+  l.getStartColumn() as startCol,
+  l.getEndLine() as endLine,
+  l.getEndColumn() as endCol

--- a/analysis/kernel/dashboard/queries/syscall-node-pairs.ql
+++ b/analysis/kernel/dashboard/queries/syscall-node-pairs.ql
@@ -1,0 +1,105 @@
+/**
+ * @name Syscall-reachable pairs
+ * @description Emits (syscall, function, file) for every function reachable from each
+ *   __do_sys_* entry over the full call graph (direct + indirect calls). Emitting
+ *   the relative file path provides an exact join key (function, file) for location
+ *   assembly while avoiding dynamic string concatenation in QL to prevent string-pool
+ *   exhaustion.
+ * @id cpp/dashboard/syscall-node-pairs
+ * @kind table
+ */
+
+import cpp
+import semmle.code.cpp.pointsto.CallGraph
+import semmle.code.cpp.ir.dataflow.ResolveCall
+import semmle.code.cpp.dataflow.new.TaintTracking
+
+module IndirectFlowConfiguration implements DataFlow::ConfigSig {
+  predicate isSource(DataFlow::Node source) {
+    source.asConvertedExpr() instanceof FunctionAccess or
+    source.asIndirectConvertedExpr() instanceof FunctionAccess
+  }
+  predicate isSink(DataFlow::Node sink) {
+    exists(ExprCall ec |
+      sink.asConvertedExpr() = ec.getExpr() or
+      sink.asIndirectConvertedExpr() = ec.getExpr()
+    )
+  }
+}
+
+IndirectFlow::PathNode getPathNode(Element e) {
+  exists(IndirectFlow::PathNode pn, DataFlow::Node n |
+    result = pn and pn.getNode() = n and n.getLocation() = e.getLocation()
+  )
+}
+
+module IndirectFlow = TaintTracking::Global<IndirectFlowConfiguration>;
+
+class ExprTargetCallEdge extends AdditionalControlFlowEdge {
+  ExprTargetCallEdge() { exists(Function fun | mkElement(this) = fun) }
+  override ControlFlowNode getAnEdgeTarget() {
+    exists(ExprCall e | e.getEnclosingFunction() = mkElement(this) and result = e.getExpr())
+  }
+}
+
+cached
+class ExprSourceCallEdge extends AdditionalControlFlowEdge {
+  cached ExprSourceCallEdge() { exists(ExprCall expc | mkElement(this) = expc.getExpr()) }
+  cached override ControlFlowNode getAnEdgeTarget() {
+    exists(IndirectFlow::PathNode target |
+      IndirectFlow::flowPath(target, getPathNode(mkElement(this))) and
+      target.getNode().asConvertedExpr() = mkElement(result).(Function).getAnAccess()
+      or
+      target.getNode().asIndirectConvertedExpr() = mkElement(result).(Function).getAnAccess()
+    )
+  }
+}
+
+cached predicate exprCallEdge(ExprCall a, Function b) {
+  a.getExpr().(TargetPointsToExpr).pointsTo() = b and
+  a.getExpr().(TargetPointsToExpr).confidence() >= 0.2 and
+  exists(int numParams |
+    numParams = count(b.getParameter(_)) and
+    forall(int i | i in [0 .. numParams - 1] |
+      exists(Parameter p | p = b.getParameter(i) |
+        exists(Type paramType | paramType = p.getType() |
+          exists(Expr arg | arg = a.getArgument(i) |
+            arg.getType().(PointerType).getBaseType() = paramType or
+            arg.getType() = paramType
+          )
+        )
+      )
+    )
+  )
+}
+
+predicate notInteresting(Function fun) {
+  fun.getName().matches("__compiletime_assert_%") or
+  fun.getName().matches("__builtin_%") or
+  not exists(fun.getBlock()) or
+  fun.getBlock().isEmpty()
+}
+
+predicate edges(ControlFlowNode a, ControlFlowNode b) {
+  exprCallEdge(a, b) and not notInteresting(b)
+  or a = b.(ExprCall).getEnclosingFunction() and not notInteresting(a)
+  or a = b.(FunctionCall).getEnclosingFunction() and not notInteresting(a)
+  or a.(FunctionCall).getTarget() = b and not notInteresting(b)
+  or a.(ExprTargetCallEdge).(Function) = b.(Call).getEnclosingFunction()
+  or a.(ExprSourceCallEdge).getAnEdgeTarget() = b.(ExprTargetCallEdge)
+  or b = resolveCall(a) and not notInteresting(b)
+}
+
+class SyscallEntry extends Function {
+  SyscallEntry() { this.getName().regexpMatch("__do_sys_.*") and exists(this.getBlock()) }
+}
+
+from SyscallEntry entry, Function reached
+where
+  edges+(entry, reached) and
+  reached != entry and
+  not notInteresting(reached)
+select
+  entry.getName() as syscall,
+  reached.getName() as function,
+  reached.getFile().getRelativePath() as file


### PR DESCRIPTION
This PR introduces a split CodeQL query pipeline (syscall-node-pairs.ql and syscall-node-locs.ql) and an importer script (import_syscall_node.py) to construct the kernel syscall_node reachability table. The two-stage design resolves CodeQL string-pool memory exhaustion (PoolGrowthError / 2GiB limit) that occurs when assembling formatted location strings directly in QL on large kernels. By projecting (syscall, function, file) in the reachability query, the importer performs an exact (function, file) join against discrete location coordinates, eliminating cross-file Cartesian explosions caused by non-unique C function names. Both queries explicitly prune compiler assertions, builtins, and bodyless extern declarations to prevent stub edges from polluting reachability data. 